### PR TITLE
Compile sources to JavaScript

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /api.json
 /docs
 /remote-sync.json
+/index.js

--- a/index.js
+++ b/index.js
@@ -1,2 +1,0 @@
-require('coffee-script/register');
-module.exports = require('./index.coffee');

--- a/package.json
+++ b/package.json
@@ -16,16 +16,19 @@
     }
   ],
   "scripts": {
+    "compile": "coffee --bare --compile index.coffee",
+    "prepublish": "npm run compile",
+    "pretest": "npm run compile",
     "test": "mocha --compilers coffee:coffee-script/register --require test/env -- test/*.test.coffee"
   },
   "dependencies": {
-    "coffee-script": "1.10.0",
     "inflection": "1.7.1",
     "mongodb": "2.0.48",
     "q": "1.4.1",
     "underscore": "1.8.3"
   },
   "devDependencies": {
+    "coffee-script": "1.10.0",
     "chai": "3.4.0",
     "del": "2.1.0",
     "endokken": "0.3.0",

--- a/test/env.coffee
+++ b/test/env.coffee
@@ -5,7 +5,7 @@ _ = require 'underscore'
 
 _.extend global,
   mongodb_uri: 'mongodb://localhost/mabolo-test'
-  Mabolo: require '../index'
+  Mabolo: require '..'
   expect: chai.expect
   Q: require 'q'
   _: _


### PR DESCRIPTION
Requiring `coffee-script/register` should be considered as a destructive action to users' environment.
